### PR TITLE
I don't know why this doesn't work

### DIFF
--- a/SourceryTextb1/ColoredTextMatrix.java
+++ b/SourceryTextb1/ColoredTextMatrix.java
@@ -1,8 +1,9 @@
 package SourceryTextb1;
 
+import SourceryTextb1.GameClock;
+
 import javax.swing.*;
 import java.awt.*;
-import java.util.Timer;
 import java.util.TimerTask;
 
 import static java.lang.Math.abs;
@@ -34,8 +35,7 @@ public class ColoredTextMatrix extends JPanel{
         setFont(new Font("Monospaced", Font.PLAIN, CHAR_SIZE));
         setFocusable(true);
 
-        Timer timing = new Timer();
-        timing.scheduleAtFixedRate(new frameResetTimer(), 25, 25);
+        GameClock.timer.scheduleAtFixedRate(new frameResetTimer(), 25, 25);
     }
 
     @Override

--- a/SourceryTextb1/GameClock.java
+++ b/SourceryTextb1/GameClock.java
@@ -1,0 +1,13 @@
+package SourceryTextb1;
+
+import java.util.Timer;
+
+/**
+ * Created by ZachLLogan on 11/2/2016.
+ *
+ * Purpose: (temporary?) solution to having too many timer threads
+ */
+
+public class GameClock {
+    public static Timer timer = new Timer();;
+}

--- a/SourceryTextb1/GameInstance.java
+++ b/SourceryTextb1/GameInstance.java
@@ -3,6 +3,7 @@ package SourceryTextb1;
 import SourceryTextb1.GameObjects.Player;
 import SourceryTextb1.GameObjects.PlayerKeyPressListener;
 import SourceryTextb1.Rooms.Room;
+import SourceryTextb1.GameClock;
 
 import java.awt.*;
 import java.util.*;
@@ -32,7 +33,7 @@ public class GameInstance {
     public void runGame(){
         protaganist.orgo.terminateClock();
         for (Player p : playerList) {
-            new Timer().schedule(new TimerTask() {
+            GameClock.timer.schedule(new TimerTask() {
                 @Override
                 public void run() {
                     while (!p.roomName.equals("die")) {

--- a/SourceryTextb1/GameObjects/GameObject.java
+++ b/SourceryTextb1/GameObjects/GameObject.java
@@ -17,6 +17,7 @@ package SourceryTextb1.GameObjects;
 import SourceryTextb1.ImageOrg;
 import SourceryTextb1.Layer;
 import SourceryTextb1.Rooms.Room;
+import SourceryTextb1.GameClock;
 
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -33,7 +34,6 @@ public class GameObject implements java.io.Serializable{
     public String strClass = "None";
     public ImageOrg orgo;
     protected Room room;
-    transient Timer timer;
     int frequency;
     
     protected int x;
@@ -232,15 +232,14 @@ public class GameObject implements java.io.Serializable{
     public void setupTimer(int theFrequency){
         cancelTimer();
         frequency = theFrequency;
-        timer = new Timer();
         updateTimerInstance = new updateTimer(frequency);
-        timer.scheduleAtFixedRate(updateTimerInstance, frequency, frequency);
+        GameClock.timer.scheduleAtFixedRate(updateTimerInstance, frequency, frequency);
     }
 
     public void cancelTimer(){
         try {
-            timer.cancel();
-            timer.purge();
+            updateTimerInstance.cancel();
+            GameClock.timer.purge();
         }
         catch (NullPointerException ignore){}
     }

--- a/SourceryTextb1/GameObjects/Inventory.java
+++ b/SourceryTextb1/GameObjects/Inventory.java
@@ -236,8 +236,7 @@ class Inventory implements java.io.Serializable {
         Navigator keyListener = new Navigator(this);
         window.txtArea.addKeyListener(keyListener); // Add key listeners.
 
-        Timer timer = new Timer();
-        timer.scheduleAtFixedRate(new MenuTimer(window, keyListener), 10 , 99);
+        GameClock.timer.scheduleAtFixedRate(new MenuTimer(window, keyListener), 10 , 99);
     }
 
     /**

--- a/SourceryTextb1/GameObjects/Mortal.java
+++ b/SourceryTextb1/GameObjects/Mortal.java
@@ -1,6 +1,7 @@
 package SourceryTextb1.GameObjects;
 
 import SourceryTextb1.SpecialText;
+import SourceryTextb1.GameClock;
 
 import java.awt.*;
 import java.util.*;
@@ -77,8 +78,7 @@ public class Mortal extends GameObject implements java.io.Serializable{
                 dmgIcon = new SpecialText("X", new Color(255, 90, 70));
             }
             setDispIcon(dmgIcon);
-            Timer timing = new Timer();
-            timing.schedule(new dmgTimer(), 250);
+            GameClock.timer.schedule(new dmgTimer(), 250);
         }
     }
 

--- a/SourceryTextb1/ImageOrg.java
+++ b/SourceryTextb1/ImageOrg.java
@@ -5,9 +5,10 @@
  */
 package SourceryTextb1;
 
+import SourceryTextb1.GameClock;
+
 import java.util.ArrayList;
 import java.util.ConcurrentModificationException;
-import java.util.Timer;
 import java.util.TimerTask;
 
 /**
@@ -25,13 +26,13 @@ public class ImageOrg implements java.io.Serializable {
     private int camY = 0;
     private boolean debugGame = false;
 
-    //FrameTimer frameTimerInstance = new FrameTimer();
-    private Timer drawTimer = new Timer();
+    private FrameTimer frameTimerInstance;
 
     final int orgSerial = (int) (Math.random() * 10000);
 
     public ImageOrg(Window game) {
         //drawTimer.scheduleAtFixedRate(frameTimerInstance, 0, 50); //20 fps lock
+        frameTimerInstance = new FrameTimer();
         resetClock();
         window = game;
     }
@@ -44,20 +45,15 @@ public class ImageOrg implements java.io.Serializable {
     }
 
     public void resetClock() {
-        try {
-            drawTimer.cancel();
-        } catch (NullPointerException ignore) {
-        }
-        drawTimer = new Timer();
-        drawTimer.scheduleAtFixedRate(new FrameTimer(), 0, 50); //20 fps lock
+        frameTimerInstance.cancel();
+        GameClock.timer.purge();
+        frameTimerInstance = new FrameTimer();
+        GameClock.timer.scheduleAtFixedRate(frameTimerInstance, 0, 50); //20 fps lock
     }
 
     public void terminateClock() {
-        if (drawTimer != null) {
-            drawTimer.cancel();
-            drawTimer.purge();
-            drawTimer = null;
-        }
+        frameTimerInstance.cancel();
+        GameClock.timer.purge();
     }
 
     /**

--- a/SourceryTextb1/UserScreens/MainMenu.java
+++ b/SourceryTextb1/UserScreens/MainMenu.java
@@ -9,7 +9,6 @@ import java.awt.*;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 import java.io.*;
-import java.util.Timer;
 import java.util.TimerTask;
 
 
@@ -39,8 +38,7 @@ class MainMenu {
         window = theWindow;
         starter = start;
         wincnfg = new WindowConfig(orgo);
-        Timer time = new Timer();
-        time.scheduleAtFixedRate(new MenuTimer(), 0, 100);
+        GameClock.timer.scheduleAtFixedRate(new MenuTimer(), 0, 100);
 
         keyInputter = new KeyInput(this);
         window.txtArea.addKeyListener(keyInputter);

--- a/SourceryTextb1/UserScreens/Start.java
+++ b/SourceryTextb1/UserScreens/Start.java
@@ -27,6 +27,7 @@ public class Start {
     private static List<Player> playerList; // for multiplayer!
 
     public static void main(String[] args) throws InterruptedException {
+        GameClock clock = new GameClock();
         game = new Window();
         Layer base = new Layer(new String[game.maxH()][game.maxW()], "base");
         org = new ImageOrg(game);
@@ -48,9 +49,7 @@ public class Start {
         } else {
             WindowConfig wincnfg = new WindowConfig(org);
             wincnfg.config(false);
-
-            Timer time = new Timer();
-            time.schedule(new StartCheck(wincnfg), 50, 100);
+            GameClock.timer.schedule(new StartCheck(wincnfg), 50, 100);
         }
     }
 
@@ -315,7 +314,7 @@ public class Start {
             player.roomName = "TutorialBasement";
             playerList.add(player);
             GameInstance master = new GameInstance(initializeZone1Rooms(player),player);
-            new Timer().schedule(new TimerTask() {
+            GameClock.timer.schedule(new TimerTask() {
                 @Override
                 public void run() {
                     master.runGame();
@@ -326,7 +325,7 @@ public class Start {
             for (int i=1; i<numPlayers; i++) {
                 System.out.println("Adding multiplayer player #"+i);
                 SlaveGameInstance instance = new SlaveGameInstance(master);
-                new Timer().schedule(new TimerTask() {
+                GameClock.timer.schedule(new TimerTask() {
                     @Override
                     public void run() {
                         instance.runGameAsSlaveTo(master);

--- a/SourceryTextb1/UserScreens/WindowConfig.java
+++ b/SourceryTextb1/UserScreens/WindowConfig.java
@@ -2,11 +2,11 @@ package SourceryTextb1.UserScreens;
 
 import SourceryTextb1.*;
 import SourceryTextb1.Window;
+import SourceryTextb1.GameClock;
 
 import java.awt.*;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
-import java.util.Timer;
 import java.util.TimerTask;
 
 /**
@@ -69,8 +69,7 @@ class WindowConfig {
 
             System.out.println("WinCnfg: keyListener created");
 
-            Timer update = new Timer();
-            update.schedule(new StopListener(keyListener), 0, 100);
+            GameClock.timer.schedule(new StopListener(keyListener), 0, 100);
         }
         else{
             exit();


### PR DESCRIPTION
I believe one reason for the high CPU usage could be the large number of timers their are, so I made a version with only one global timer, but it doesn't work. It freezes when I press enter on a menu item (though if I keep pressing enter, if I was on new game, it will print to the console that the player and hud layers were not found.)

I am not too familiar with the code yet, so it is a bit hard to figure out what is wrong; I was thinking one of  you guys @HazilTheNut @random-person-001 might be able to figure out what is wrong.

This solution to getting rid of the threads might be temporary as their are other ways; for example, while a decent amount of work to switch to, swing timers might be better (they are automatically on a single thread I believe.)

Anyhow I wanted to get a quick solution to see the performance affects, but I can't because it doesn't work and I can't figure out why (the code looks functionally identical to me!)